### PR TITLE
Added googlebot, bingbot, and yandex to list of user agents

### DIFF
--- a/prerender-cloudfront.yaml
+++ b/prerender-cloudfront.yaml
@@ -52,7 +52,7 @@ Resources:
                 const user_agent = headers['user-agent'];
                 const host = headers['host'];
                 if (user_agent && host) {
-                  var prerender = /baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i.test(user_agent[0].value);
+                  var prerender = /googlebot|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i.test(user_agent[0].value);
                   prerender = prerender || /_escaped_fragment_/.test(request.querystring);
                   prerender = prerender && ! /\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)$/i.test(request.uri);
                   if (prerender) {


### PR DESCRIPTION
Google is changing the way they crawl and will no longer crawl the _escaped_fragment_ URLs. This adds a few user agents to future-proof this library and allow users to serve prerendered pages to the crawlers correctly. We have already updated out official middleware with this change as well.

Thanks!