### PR TITLE
Updating lambda runtimes to nodejs10.x

### DIFF
--- a/prerender-cloudfront.yaml
+++ b/prerender-cloudfront.yaml
@@ -63,7 +63,7 @@ Resources:
                 }
                 callback(null, request);
             };
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
   SetPrerenderHeaderVersion3:
     Type: "AWS::Lambda::Version"
     Properties:
@@ -100,7 +100,7 @@ Resources:
               }
               callback(null, request);
           };
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
   RedirectToPrerenderVersion1:
     Type: "AWS::Lambda::Version"
     Properties:


### PR DESCRIPTION
Lambda no longer supports nodejs8.10, but updating to nodejs10.x will work.